### PR TITLE
feat(Task23): 在Utils类中添加方法支持导出Pem/P12格式私钥

### DIFF
--- a/src/main/java/com/webank/weid/exception/LoadKeyStoreException.java
+++ b/src/main/java/com/webank/weid/exception/LoadKeyStoreException.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2014-2020 [fisco-dev]
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webank.weid.exception;
+
+/** Exceptioned when calling KeyManager. */
+public class LoadKeyStoreException extends RuntimeException {
+    public LoadKeyStoreException(String message) {
+        super(message);
+    }
+
+    public LoadKeyStoreException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/webank/weid/exception/SaveKeyStoreException.java
+++ b/src/main/java/com/webank/weid/exception/SaveKeyStoreException.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2014-2020 [fisco-dev]
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webank.weid.exception;
+
+/** Exceptioned when save the CryptoKeyPair into p12 or pem */
+public class SaveKeyStoreException extends RuntimeException {
+    public SaveKeyStoreException(String message) {
+        super(message);
+    }
+
+    public SaveKeyStoreException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/webank/weid/util/keystore/KeyTool.java
+++ b/src/main/java/com/webank/weid/util/keystore/KeyTool.java
@@ -1,0 +1,409 @@
+/**
+ * Copyright 2014-2020 [fisco-dev]
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webank.weid.util.keystore;
+
+import com.webank.weid.exception.LoadKeyStoreException;
+import org.bouncycastle.crypto.params.ECDomainParameters;
+import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey;
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
+import org.bouncycastle.jcajce.provider.asymmetric.util.EC5Util;
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
+import org.bouncycastle.jce.spec.ECNamedCurveSpec;
+import org.bouncycastle.jce.spec.ECPrivateKeySpec;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemWriter;
+import org.fisco.bcos.web3j.utils.Numeric;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.math.BigInteger;
+import java.security.*;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+import java.util.Collections;
+
+public abstract class KeyTool {
+    protected static Logger logger = LoggerFactory.getLogger(KeyTool.class);
+
+    protected final String keyStoreFile;
+    protected final String password;
+    protected KeyStore keyStore;
+    private String hexedPublicKey = "";
+
+    /**
+     * Constructor for the P12: with password
+     *
+     * @param keyStoreFile the path of the keystore file
+     * @param password password to read the keystore file
+     */
+    public KeyTool(final String keyStoreFile, final String password) {
+        this.keyStoreFile = keyStoreFile;
+        this.password = password;
+        initSecurity();
+        load();
+    }
+
+    /**
+     * Constructor for PEM without password
+     *
+     * @param keyStoreFile the path of the keystore file
+     */
+    public KeyTool(final String keyStoreFile) {
+        this(keyStoreFile, null);
+    }
+
+    /**
+     * Constructor for the P12: with password and key file input stream
+     *
+     * @param keyStoreFileInputStream the input stream of the keystore file
+     * @param password password to read the keystore file
+     */
+    public KeyTool(InputStream keyStoreFileInputStream, final String password) {
+        this.keyStoreFile = null;
+        this.password = password;
+        initSecurity();
+        this.load(keyStoreFileInputStream);
+    }
+
+    /**
+     * Constructor for PEM with key file input stream
+     *
+     * @param keyStoreFileInputStream the input stream of the keystore file
+     */
+    public KeyTool(InputStream keyStoreFileInputStream) {
+        this(keyStoreFileInputStream, null);
+    }
+
+    protected abstract PrivateKey getPrivateKey();
+
+    private static void initSecurity() {
+        Security.setProperty("crypto.policy", "unlimited");
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    public final String getKeyStoreFile() {
+        return this.keyStoreFile;
+    }
+
+    /**
+     * Get keyPair loaded from the keyStore file
+     *
+     * @return the keyPair
+     */
+    public KeyPair getKeyPair() {
+        PrivateKey privateKey = getPrivateKey();
+        PublicKey publicKey = getPublicKeyFromPrivateKey();
+        return new KeyPair(publicKey, privateKey);
+    }
+
+    /**
+     * Abstract function of getting public key
+     *
+     * @return PublicKey
+     */
+    protected abstract PublicKey getPublicKey();
+
+    public static String getHexedPublicKey(PublicKey publicKey) {
+        byte[] publicKeyBytes = ((BCECPublicKey) publicKey).getQ().getEncoded(false);
+        BigInteger publicKeyValue =
+                new BigInteger(1, Arrays.copyOfRange(publicKeyBytes, 1, publicKeyBytes.length));
+        return Numeric.toHexStringNoPrefixZeroPadded(publicKeyValue, 128);
+    }
+
+    /**
+     * Get hex string type public key
+     *
+     * @return hex string of a public key
+     */
+    public String getHexedPublicKey() {
+        if (!"".equals(hexedPublicKey)) {
+            return this.hexedPublicKey;
+        }
+        this.hexedPublicKey = getHexedPublicKey(getPublicKey());
+        return this.hexedPublicKey;
+    }
+
+    /**
+     * Get hex string type private key
+     *
+     * @param privateKey PrivateKey type private key
+     * @return the hex string type private key
+     */
+    public static String getHexedPrivateKey(PrivateKey privateKey) {
+        return Numeric.toHexStringNoPrefixZeroPadded(((BCECPrivateKey) privateKey).getD(), 64);
+    }
+
+    /**
+     * convert hexed string into PrivateKey type storePublicKeyWithPem
+     *
+     * @param hexedPrivateKey the hexed privateKey
+     * @param curveName the curve name
+     * @return the converted privateKey
+     * @throws LoadKeyStoreException convert exception, return exception information
+     */
+    public static PrivateKey convertHexedStringToPrivateKey(
+            String hexedPrivateKey, String curveName) throws LoadKeyStoreException {
+        BigInteger privateKeyValue = new BigInteger(hexedPrivateKey, 16);
+        return convertHexedStringToPrivateKey(privateKeyValue, curveName);
+    }
+
+    /**
+     * Convert BigInteger private key and ECC curve name to PrivateKey type key
+     *
+     * @param privateKey BigInteger type private key
+     * @param curveName the ECC curve name
+     * @return PrivateKey
+     */
+    public static PrivateKey convertHexedStringToPrivateKey(
+            BigInteger privateKey, String curveName) {
+        return convertPrivateKeyToKeyPair(privateKey, curveName).getPrivate();
+    }
+
+    /**
+     * Convert string type private key integer and ECC curve name to PrivateKey type key
+     *
+     * @param hexedPrivateKey string type of the private key integer
+     * @param curveName ECC curve name
+     * @return KeyPair
+     * @throws LoadKeyStoreException
+     */
+    public static KeyPair convertHexedStringToKeyPair(String hexedPrivateKey, String curveName)
+            throws LoadKeyStoreException {
+        BigInteger privateKeyValue = new BigInteger(hexedPrivateKey, 16);
+        return convertPrivateKeyToKeyPair(privateKeyValue, curveName);
+    }
+
+    /**
+     * Convert BigInteger private key and ECC curve name to KeyPair
+     *
+     * @param privateKey BigInteger type private key
+     * @param curveName ECC curve name
+     * @return KeyPair
+     * @throws LoadKeyStoreException
+     */
+    public static KeyPair convertPrivateKeyToKeyPair(BigInteger privateKey, String curveName)
+            throws LoadKeyStoreException {
+        try {
+            initSecurity();
+            org.bouncycastle.jce.spec.ECParameterSpec ecParameterSpec =
+                    ECNamedCurveTable.getParameterSpec(curveName);
+            ECPrivateKeySpec privateKeySpec = new ECPrivateKeySpec(privateKey, ecParameterSpec);
+            KeyFactory keyFactory =
+                    KeyFactory.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+            // get private key
+            BCECPrivateKey privateKeyObject =
+                    (BCECPrivateKey) keyFactory.generatePrivate(privateKeySpec);
+            PublicKey publicKey = getPublicKeyFromPrivateKey(privateKeyObject);
+            ECPrivateKeyParameters ecPrivateKeyParameters =
+                    new ECPrivateKeyParameters(
+                            privateKeyObject.getD(),
+                            new ECDomainParameters(
+                                    ecParameterSpec.getCurve(),
+                                    ecParameterSpec.getG(),
+                                    ecParameterSpec.getN()));
+            BCECPrivateKey bcecPrivateKey =
+                    new BCECPrivateKey(
+                            privateKeyObject.getAlgorithm(),
+                            ecPrivateKeyParameters,
+                            (BCECPublicKey) publicKey,
+                            ecParameterSpec,
+                            BouncyCastleProvider.CONFIGURATION);
+            return new KeyPair(publicKey, bcecPrivateKey);
+        } catch (NoSuchProviderException | InvalidKeySpecException | NoSuchAlgorithmException e) {
+            throw new LoadKeyStoreException(
+                    "covert private key into PrivateKey type failed, "
+                            + " error information: "
+                            + e.getMessage(),
+                    e);
+        }
+    }
+
+    /**
+     * Generate public key from private key, and store public key in to pem key file
+     *
+     * @param privateKey a private key
+     * @param privateKeyFilePath the pem key file
+     * @throws IOException
+     */
+    public static void storePublicKeyWithPem(PrivateKey privateKey, String privateKeyFilePath)
+            throws IOException {
+        PublicKey publicKey = getPublicKeyFromPrivateKey(privateKey);
+        storePublicKeyWithPem(publicKey, privateKeyFilePath);
+    }
+
+    /**
+     * Store public key in to pem key file
+     *
+     * @param publicKey a public key
+     * @param privateKeyFilePath the pem key file
+     * @throws IOException
+     */
+    public static void storePublicKeyWithPem(PublicKey publicKey, String privateKeyFilePath)
+            throws IOException {
+        String publicKeyPath = privateKeyFilePath + ".pub";
+        PemWriter writer = new PemWriter(new FileWriter(publicKeyPath));
+        writer.writeObject(new PemObject("PUBLIC KEY", publicKey.getEncoded()));
+        writer.flush();
+        writer.close();
+    }
+
+    /**
+     * Abstract function of load key from InputStream
+     *
+     * @param in the InputStream
+     */
+    protected abstract void load(InputStream in);
+
+    /** load information from the keyStoreFile */
+    protected void load() {
+        try {
+            InputStream keyStoreFileInputStream = new FileInputStream(keyStoreFile);
+            this.load(keyStoreFileInputStream);
+        } catch (FileNotFoundException | org.bouncycastle.util.encoders.DecoderException e) {
+            String errorMessage =
+                    "load keys from "
+                            + keyStoreFile
+                            + " failed for FileNotFoundException, error message:"
+                            + e.getMessage();
+            logger.error(errorMessage);
+            throw new LoadKeyStoreException(errorMessage, e);
+        }
+    }
+
+    private static Method getMethod(
+            Class<EC5Util> ec5UtilClass, String methodName, Class<?>... parameterTypes) {
+        try {
+            return ec5UtilClass.getDeclaredMethod(methodName, parameterTypes);
+        } catch (NoSuchMethodException e) {
+            logger.debug("try to get method for EC5Util failed, method name: {}", methodName);
+            return null;
+        }
+    }
+
+    private static org.bouncycastle.jce.spec.ECParameterSpec convertToECParamSpec(
+            ECParameterSpec _ecParams) throws LoadKeyStoreException {
+        try {
+            Class<EC5Util> ec5UtilClass = EC5Util.class;
+            String methodName = "convertSpec";
+            Object ecParamSpec = null;
+            Object ec5utilObject = ec5UtilClass.newInstance();
+            Method methodDeclare = getMethod(ec5UtilClass, methodName, ECParameterSpec.class);
+            if (methodDeclare != null) {
+                ecParamSpec = methodDeclare.invoke(ec5utilObject, _ecParams);
+
+            } else {
+                methodDeclare =
+                        getMethod(ec5UtilClass, methodName, ECParameterSpec.class, boolean.class);
+                if (methodDeclare != null) {
+                    ecParamSpec = methodDeclare.invoke(ec5utilObject, _ecParams, false);
+                }
+            }
+            if (ecParamSpec != null) {
+                return (org.bouncycastle.jce.spec.ECParameterSpec) ecParamSpec;
+            }
+            logger.error(
+                    "convertToECParamSpec exception for {} not found, supported methodList: {}",
+                    methodName,
+                    (ec5UtilClass.getMethods() != null
+                            ? ec5UtilClass.getMethods().toString()
+                            : " none"));
+            throw new LoadKeyStoreException(
+                    "convertToECParamSpec exception for "
+                            + methodName
+                            + " not found! Please check the version of bcprov-jdk15on!");
+        } catch (IllegalAccessException | InvocationTargetException | InstantiationException e) {
+            logger.error(
+                    "convertToECParamSpec exception, error: {}, e: {}",
+                    e.getMessage(),
+                    e.getStackTrace().toString());
+            throw new LoadKeyStoreException("convertToECParamSpec exception for " + e.getMessage());
+        }
+    }
+
+    /**
+     * Get the public key
+     *
+     * @return PublicKey
+     */
+    protected PublicKey getPublicKeyFromPrivateKey() {
+        return getPublicKeyFromPrivateKey(getPrivateKey());
+    }
+
+    /**
+     * Generate and get the public key from private key
+     *
+     * @param privateKey the PrivateKey
+     * @return the PublicKey
+     * @throws LoadKeyStoreException
+     */
+    public static PublicKey getPublicKeyFromPrivateKey(PrivateKey privateKey)
+            throws LoadKeyStoreException {
+        try {
+            initSecurity();
+            ECPrivateKey ecPrivateKey = (ECPrivateKey) privateKey;
+            ECParameterSpec params = ecPrivateKey.getParams();
+
+            org.bouncycastle.jce.spec.ECParameterSpec bcSpec = convertToECParamSpec(params);
+            org.bouncycastle.math.ec.ECPoint q = bcSpec.getG().multiply(ecPrivateKey.getS());
+            org.bouncycastle.math.ec.ECPoint bcW =
+                    bcSpec.getCurve().decodePoint(q.getEncoded(false));
+            ECPoint w =
+                    new ECPoint(
+                            bcW.getAffineXCoord().toBigInteger(),
+                            bcW.getAffineYCoord().toBigInteger());
+            ECPublicKeySpec keySpec = new ECPublicKeySpec(w, tryFindNamedCurveSpec(params));
+            return (PublicKey)
+                    KeyFactory.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME)
+                            .generatePublic(keySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException | NoSuchProviderException e) {
+            String errorMessage =
+                    "get publicKey from given the private key failed, error message:"
+                            + e.getMessage();
+            logger.error(errorMessage);
+            throw new LoadKeyStoreException(errorMessage, e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ECParameterSpec tryFindNamedCurveSpec(ECParameterSpec params)
+            throws LoadKeyStoreException {
+        org.bouncycastle.jce.spec.ECParameterSpec bcSpec = convertToECParamSpec(params);
+        for (Object name : Collections.list(ECNamedCurveTable.getNames())) {
+            ECNamedCurveParameterSpec bcNamedSpec =
+                    ECNamedCurveTable.getParameterSpec((String) name);
+            if (bcNamedSpec.getN().equals(bcSpec.getN())
+                    && bcNamedSpec.getH().equals(bcSpec.getH())
+                    && bcNamedSpec.getCurve().equals(bcSpec.getCurve())
+                    && bcNamedSpec.getG().equals(bcSpec.getG())) {
+                return new ECNamedCurveSpec(
+                        bcNamedSpec.getName(),
+                        bcNamedSpec.getCurve(),
+                        bcNamedSpec.getG(),
+                        bcNamedSpec.getN(),
+                        bcNamedSpec.getH(),
+                        bcNamedSpec.getSeed());
+            }
+        }
+        return params;
+    }
+}

--- a/src/main/java/com/webank/weid/util/keystore/P12KeyStore.java
+++ b/src/main/java/com/webank/weid/util/keystore/P12KeyStore.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright 2014-2020 [fisco-dev]
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webank.weid.util.keystore;
+
+import com.webank.weid.exception.LoadKeyStoreException;
+import com.webank.weid.exception.SaveKeyStoreException;
+import org.bouncycastle.crypto.tls.SignatureAlgorithm;
+import org.bouncycastle.jce.X509Principal;
+import org.bouncycastle.x509.X509V3CertificateGenerator;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Calendar;
+import java.util.Enumeration;
+
+public class P12KeyStore extends KeyTool {
+    private static final String NAME = "key";
+    private KeyStore keyStore;
+
+    public P12KeyStore(final String keyStoreFile, final String password) {
+        super(keyStoreFile, password);
+    }
+
+    public P12KeyStore(InputStream keyStoreFileInputStream, final String password) {
+        super(keyStoreFileInputStream, password);
+    }
+
+    @Override
+    public PublicKey getPublicKey() {
+        try {
+            Enumeration<String> aliases = keyStore.aliases();
+            Certificate certificate = null;
+            while (aliases.hasMoreElements() && certificate == null) {
+                certificate = keyStore.getCertificate(aliases.nextElement());
+            }
+            if (certificate == null) {
+                throw new LoadKeyStoreException(
+                        "getPublicKey from p12 file " + keyStoreFile + "failed");
+            }
+            return certificate.getPublicKey();
+        } catch (KeyStoreException e) {
+            throw new LoadKeyStoreException(
+                    "getPublicKey from p12 file "
+                            + keyStoreFile
+                            + " failed, error message: "
+                            + e.getMessage(),
+                    e);
+        }
+    }
+
+    /**
+     * load keyPair from the given input stream
+     *
+     * @param in the input stream that should used to load keyPair
+     */
+    @Override
+    protected void load(InputStream in) {
+        try {
+            keyStore = KeyStore.getInstance("PKCS12", "BC");
+            String password = "";
+            if (this.password != null) {
+                password = this.password;
+            }
+            keyStore.load(in, password.toCharArray());
+
+        } catch (IOException
+                | CertificateException
+                | NoSuchAlgorithmException
+                | NoSuchProviderException
+                | KeyStoreException e) {
+            String errorMessage =
+                    "load keys from p12 file "
+                            + keyStoreFile
+                            + " failed, error message:"
+                            + e.getMessage();
+            logger.error(errorMessage);
+            throw new LoadKeyStoreException(errorMessage, e);
+        }
+    }
+
+    /**
+     * get private key from the keyStore
+     *
+     * @return the private key
+     */
+    @Override
+    protected PrivateKey getPrivateKey() {
+        try {
+            Enumeration<String> aliases = keyStore.aliases();
+            PrivateKey privateKey = null;
+            while (aliases.hasMoreElements() && privateKey == null) {
+                privateKey =
+                        (PrivateKey) keyStore.getKey(aliases.nextElement(), password.toCharArray());
+            }
+            if (privateKey == null) {
+                throw new LoadKeyStoreException(
+                        "getPrivateKey from p12 file " + keyStoreFile + "failed");
+            }
+            return privateKey;
+        } catch (UnrecoverableKeyException | NoSuchAlgorithmException | KeyStoreException e) {
+            String errorMessage =
+                    "get private key from "
+                            + keyStoreFile
+                            + " failed for UnrecoverableKeyException, error message"
+                            + e.getMessage();
+            logger.error(errorMessage);
+            throw new LoadKeyStoreException(errorMessage, e);
+        }
+    }
+
+    public static void storeKeyPairWithP12Format(
+            String hexedPrivateKey,
+            String password,
+            String privateKeyFilePath,
+            String curveName,
+            String signatureAlgorithm)
+            throws SaveKeyStoreException {
+        try {
+            hexedPrivateKey = hexedPrivateKey.startsWith("0x") ? hexedPrivateKey.substring(2) : hexedPrivateKey;
+            PrivateKey privateKey = convertHexedStringToPrivateKey(hexedPrivateKey, curveName);
+            // save the private key
+            KeyStore keyStore = KeyStore.getInstance("PKCS12", "BC");
+            // load to init the keyStore
+            keyStore.load(null, password.toCharArray());
+            KeyPair keyPair = new KeyPair(getPublicKeyFromPrivateKey(privateKey), privateKey);
+            // Since KeyStore setEntry must set the certificate chain, a self-signed certificate is
+            // generated
+            Certificate[] certChain = new Certificate[1];
+            certChain[0] = generateSelfSignedCertificate(keyPair, signatureAlgorithm);
+            keyStore.setKeyEntry(NAME, privateKey, password.toCharArray(), certChain);
+            keyStore.store(new FileOutputStream(privateKeyFilePath), password.toCharArray());
+            // store the public key
+            storePublicKeyWithPem(privateKey, privateKeyFilePath);
+        } catch (IOException
+                | KeyStoreException
+                | NoSuchProviderException
+                | NoSuchAlgorithmException
+                | CertificateException
+                | LoadKeyStoreException
+                | InvalidKeyException
+                | SignatureException e) {
+            throw new SaveKeyStoreException(
+                    "save private key into "
+                            + privateKeyFilePath
+                            + " failed, error information: "
+                            + e.getMessage(),
+                    e);
+        }
+    }
+
+    /**
+     * generate self-signed certificate
+     *
+     * @param keyPair            the keyPair used to generated the certificate
+     * @param signatureAlgorithm the signature algorithm of the cert
+     * @return the generated self-signed certificate object
+     * @throws NoSuchAlgorithmException     no such algorithm exception
+     * @throws CertificateEncodingException error occurs when encoding certificate
+     * @throws NoSuchProviderException      no such provider exception
+     * @throws InvalidKeyException          invalid key exception
+     * @throws SignatureException           generic signature exception
+     */
+    public static X509Certificate generateSelfSignedCertificate(
+            KeyPair keyPair, String signatureAlgorithm)
+            throws NoSuchAlgorithmException, CertificateEncodingException, NoSuchProviderException,
+            InvalidKeyException, SignatureException {
+        X509V3CertificateGenerator cert = new X509V3CertificateGenerator();
+        cert.setSerialNumber(BigInteger.valueOf(1)); // or generate a random number
+        cert.setSubjectDN(new X509Principal("CN=localhost")); // see examples to add O,OU etc
+        cert.setIssuerDN(new X509Principal("CN=localhost")); // same since it is self-signed
+        cert.setPublicKey(keyPair.getPublic());
+        Calendar notBefore = Calendar.getInstance();
+        Calendar notAfter = Calendar.getInstance();
+        notBefore.add(Calendar.YEAR, 100);
+        cert.setNotBefore(notBefore.getTime());
+        cert.setNotAfter(notAfter.getTime());
+        cert.setSignatureAlgorithm(signatureAlgorithm);
+        cert.setPublicKey(keyPair.getPublic());
+        PrivateKey signingKey = keyPair.getPrivate();
+        return cert.generate(signingKey, "BC");
+    }
+}

--- a/src/main/java/com/webank/weid/util/keystore/PEMKeyStore.java
+++ b/src/main/java/com/webank/weid/util/keystore/PEMKeyStore.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2014-2020 [fisco-dev]
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webank.weid.util.keystore;
+
+import com.webank.weid.exception.LoadKeyStoreException;
+import com.webank.weid.exception.SaveKeyStoreException;
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemReader;
+import org.bouncycastle.util.io.pem.PemWriter;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
+public class PEMKeyStore extends KeyTool {
+    public static final String PRIVATE_KEY = "PRIVATE KEY";
+    private PemObject pem;
+
+    public PEMKeyStore(final String keyStoreFile) {
+        super(keyStoreFile);
+    }
+
+    public PEMKeyStore(InputStream keyStoreFileInputStream) {
+        super(keyStoreFileInputStream);
+    }
+
+    @Override
+    protected PublicKey getPublicKey() {
+        try {
+            X509EncodedKeySpec encodedKeySpec = new X509EncodedKeySpec(pem.getContent());
+            KeyFactory keyFactory =
+                    KeyFactory.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+            return keyFactory.generatePublic(encodedKeySpec);
+        } catch (InvalidKeySpecException | NoSuchProviderException | NoSuchAlgorithmException e) {
+            throw new LoadKeyStoreException(
+                    "getPublicKey from pem file "
+                            + keyStoreFile
+                            + " failed, error message: "
+                            + e.getMessage(),
+                    e);
+        }
+    }
+
+    public static void storeKeyPairWithPemFormat(
+            String hexedPrivateKey, String privateKeyFilePath, String curveName)
+            throws SaveKeyStoreException {
+        try {
+            hexedPrivateKey = hexedPrivateKey.startsWith("0x") ? hexedPrivateKey.substring(2) : hexedPrivateKey;
+            KeyPair keyPair = convertHexedStringToKeyPair(hexedPrivateKey, curveName);
+            // save the private key
+            PemWriter writer = new PemWriter(new FileWriter(privateKeyFilePath));
+            BCECPrivateKey bcecPrivateKey = (BCECPrivateKey) (keyPair.getPrivate());
+            writer.writeObject(new PemObject(PRIVATE_KEY, bcecPrivateKey.getEncoded()));
+            writer.flush();
+            writer.close();
+            // write the public key
+            storePublicKeyWithPem(keyPair.getPublic(), privateKeyFilePath);
+        } catch (IOException | LoadKeyStoreException e) {
+            throw new SaveKeyStoreException(
+                    "save keys into "
+                            + privateKeyFilePath
+                            + " failed, error information: "
+                            + e.getMessage(),
+                    e);
+        }
+    }
+
+    @Override
+    protected void load(InputStream in) {
+        try {
+            PemReader pemReader = new PemReader(new InputStreamReader(in));
+            pem = pemReader.readPemObject();
+            pemReader.close();
+        } catch (IOException e) {
+            String errorMessage =
+                    "load key info from the pem file "
+                            + keyStoreFile
+                            + " failed, error message:"
+                            + e.getMessage();
+            logger.error(errorMessage);
+            throw new LoadKeyStoreException(errorMessage, e);
+        }
+        if (pem == null) {
+            logger.error("The file " + keyStoreFile + " does not represent a pem account.");
+            throw new LoadKeyStoreException("The file does not represent a pem account.");
+        }
+    }
+
+    @Override
+    protected PrivateKey getPrivateKey() {
+        try {
+            PKCS8EncodedKeySpec encodedKeySpec = new PKCS8EncodedKeySpec(pem.getContent());
+            KeyFactory keyFacotry =
+                    KeyFactory.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+            return keyFacotry.generatePrivate(encodedKeySpec);
+        } catch (InvalidKeySpecException | NoSuchProviderException | NoSuchAlgorithmException e) {
+            String errorMessage =
+                    "getPrivateKey from pem file "
+                            + keyStoreFile
+                            + " failed, error message:"
+                            + e.getMessage();
+            logger.error(errorMessage);
+            throw new LoadKeyStoreException(errorMessage, e);
+        }
+    }
+
+}

--- a/src/test/java/com/webank/weid/util/TestKeyStoreUtils.java
+++ b/src/test/java/com/webank/weid/util/TestKeyStoreUtils.java
@@ -1,0 +1,49 @@
+/*
+ *       Copyright© (2018-2020) WeBank Co., Ltd.
+ *
+ *       This file is part of weid-java-sdk.
+ *
+ *       weid-java-sdk is free software: you can redistribute it and/or modify
+ *       it under the terms of the GNU Lesser General Public License as published by
+ *       the Free Software Foundation, either version 3 of the License, or
+ *       (at your option) any later version.
+ *
+ *       weid-java-sdk is distributed in the hope that it will be useful,
+ *       but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *       GNU Lesser General Public License for more details.
+ *
+ *       You should have received a copy of the GNU Lesser General Public License
+ *       along with weid-java-sdk.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.webank.weid.util;
+
+import com.webank.weid.util.keystore.P12KeyStore;
+import com.webank.weid.util.keystore.PEMKeyStore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ *
+ * @author tangxianjie
+ * @date 2022/09/11
+ */
+public class TestKeyStoreUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestKeyStoreUtils.class);
+
+    @Test
+    public void testStorePem() throws Exception {
+
+        PEMKeyStore.storeKeyPairWithPemFormat("0xed6fa6b25315ae63b9044a58989ce20c53a87b3c8bfb1b57f064adc42984f5f9", "storePem.pem", "secp256k1");
+    }
+
+    @Test
+    public void testStoreP12() {
+        P12KeyStore.storeKeyPairWithP12Format("0xb1fe02c4313e4dec3b489cd054e0e3f224b3ea8e33424f573f6122efa56c44ee","1234",
+                "storeP12.p12","secp256k1", "ECDSAWITHSHA1");
+    }
+}


### PR DESCRIPTION
feat(Task23): 在Utils类中添加方法支持导出Pem/P12格式私钥
参照 fisco-bcos-java-sdk-2.9.0 代码实现